### PR TITLE
Add additional support for array indexing in Set

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 )
 
 // Errors
@@ -557,23 +556,42 @@ var (
 
 func createInsertComponent(keys []string, setValue []byte, comma, object bool) []byte {
 	var buffer bytes.Buffer
+	isIndex := string(keys[0][0]) == "["
 	if comma {
 		buffer.WriteString(",")
 	}
-	if object {
-		buffer.WriteString("{")
-	}
-	buffer.WriteString("\"")
-	buffer.WriteString(keys[0])
-	buffer.WriteString("\":")
-	for i := 1; i < len(keys); i++ {
-		buffer.WriteString("{\"")
-		buffer.WriteString(keys[i])
+	if isIndex {
+		buffer.WriteString("[")
+	} else {
+		if object {
+			buffer.WriteString("{")
+		}
+		buffer.WriteString("\"")
+		buffer.WriteString(keys[0])
 		buffer.WriteString("\":")
 	}
+
+	for i := 1; i < len(keys); i++ {
+		if string(keys[i][0]) == "[" {
+			buffer.WriteString("[")
+		} else {
+			buffer.WriteString("{\"")
+			buffer.WriteString(keys[i])
+			buffer.WriteString("\":")
+		}
+	}
 	buffer.Write(setValue)
-	buffer.WriteString(strings.Repeat("}", len(keys)-1))
-	if object {
+	for i := len(keys) - 1; i > 0; i-- {
+		if string(keys[i][0]) == "[" {
+			buffer.WriteString("]")
+		} else {
+			buffer.WriteString("}")
+		}
+	}
+	if isIndex {
+		buffer.WriteString("]")
+	}
+	if object && !isIndex {
 		buffer.WriteString("}")
 	}
 	return buffer.Bytes()

--- a/parser_test.go
+++ b/parser_test.go
@@ -298,6 +298,46 @@ var setTests = []SetTest{
 		isFound: true,
 		data:    `{"a":"b":"d"}`,
 	},
+	{
+		desc:    "set indexed path to object on empty JSON",
+		json:    `{}`,
+		path:    []string{"top", "[0]", "middle", "[0]", "bottom"},
+		setData: `"value"`,
+		isFound: true,
+		data:    `{"top":[{"middle":[{"bottom":"value"}]}]}`,
+	},
+	{
+		desc:    "set indexed path on existing object with object",
+		json:    `{"top":[{"middle":[]}]}`,
+		path:    []string{"top", "[0]", "middle", "[0]", "bottom"},
+		setData: `"value"`,
+		isFound: true,
+		data:    `{"top":[{"middle":[{"bottom":"value"}]}]}`,
+	},
+	{
+		desc:    "set indexed path on existing object with value",
+		json:    `{"top":[{"middle":[]}]}`,
+		path:    []string{"top", "[0]", "middle", "[0]"},
+		setData: `"value"`,
+		isFound: true,
+		data:    `{"top":[{"middle":["value"]}]}`,
+	},
+	{
+		desc:    "set indexed path on empty object with value",
+		json:    `{}`,
+		path:    []string{"top", "[0]", "middle", "[0]"},
+		setData: `"value"`,
+		isFound: true,
+		data:    `{"top":[{"middle":["value"]}]}`,
+	},
+	{
+		desc:    "set indexed path on object with existing array",
+		json:    `{"top":["one", "two", "three"]}`,
+		path:    []string{"top", "[2]"},
+		setData: `"value"`,
+		isFound: true,
+		data:    `{"top":["one", "two", "value"]}`,
+	},
 }
 
 var getTests = []GetTest{


### PR DESCRIPTION
**Description**: 
Closes #117. You can now use `Set` with array indices when the full path does not already exist.

**Benchmark before change**:
```
BenchmarkJsonParserLarge-4                    	  100000	     75566 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	  500000	     13141 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium-4             	 1000000	     10421 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      7995 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      8653 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	  500000	     12323 ns/op	     624 B/op	      11 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	      1107 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       879 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	      1370 ns/op	     256 B/op	       9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	      1017 ns/op	     240 B/op	       8 allocs/op
BenchmarkJsonParserSetSmall-4                 	 5000000	      1579 ns/op	     816 B/op	       5 allocs/op
BenchmarkJsonParserDelSmall-4                 	 3000000	      1840 ns/op	       0 B/op	       0 allocs/op
```
**Benchmark after change**:
```
BenchmarkJsonParserLarge-4                    	  100000	     64982 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	 1000000	     12109 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium-4             	 1000000	      9541 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      7348 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      7987 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	 1000000	     11086 ns/op	     624 B/op	      11 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	      1005 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       799 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	      1209 ns/op	     256 B/op	       9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	      1081 ns/op	     240 B/op	       8 allocs/op
BenchmarkJsonParserSetSmall-4                 	 5000000	      1497 ns/op	     816 B/op	       5 allocs/op
BenchmarkJsonParserDelSmall-4                 	 5000000	      1721 ns/op	       0 B/op	       0 allocs/op
```