### PR TITLE
Fix bug with Get() where non-last key is not an object or array

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -254,6 +254,13 @@ func searchKeys(data []byte, keys ...string) int {
 					// If we found all keys in path
 					if keyLevel == lk {
 						return i + 1
+					} else {
+						// If there are more keys in the path, confirm the next
+						// token is the start of an array or an object
+						nextValOffset := nextToken(data[i+1:])
+						if data[i+1+nextValOffset] != '{' && data[i+1+nextValOffset] != '[' {
+							return -1
+						}
 					}
 				}
 			} else {

--- a/parser_test.go
+++ b/parser_test.go
@@ -519,6 +519,12 @@ var getTests = []GetTest{
 		data:    `{"c":"d" }`,
 	},
 	{
+		desc:    `handle non-object and skip`,
+		json:    `{"a":"d","c":{"c":[1,2]}} }`,
+		path:    []string{"a", "c"},
+		isFound: false,
+	},
+	{
 		desc:    `empty path`,
 		json:    `{"c":"d" }`,
 		path:    []string{},


### PR DESCRIPTION
**Description**: Point fix in `searchKeys()`, closes #3.

**Benchmark before change**:
```
BenchmarkJsonParserLarge-4                         50000            113187 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                       500000             13604 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-4                 500000             15819 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4          500000             15006 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4          500000             18139 ns/op             672 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4       300000             26893 ns/op             624 B/op         11 allocs/op
BenchmarkJsonParserSmall-4                       3000000              1672 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4          3000000              1973 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4          3000000              2255 ns/op             144 B/op          4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4       3000000              2087 ns/op             128 B/op          3 allocs/op
BenchmarkJsonParserSetSmall-4                    2000000              3788 ns/op             816 B/op          5 allocs/op
BenchmarkJsonParserDelSmall-4                    2000000              2741 ns/op               0 B/op          0 allocs/op
```
**Benchmark after change**:
```
BenchmarkJsonParserLarge-4                         50000            114390 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                       500000             19258 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-4                1000000             11612 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4          500000             13735 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4          500000             18309 ns/op             672 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4       300000             25352 ns/op             624 B/op         11 allocs/op
BenchmarkJsonParserSmall-4                       5000000              1812 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4          3000000              2032 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4          3000000              2308 ns/op             144 B/op          4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4       5000000              2159 ns/op             128 B/op          3 allocs/op
BenchmarkJsonParserSetSmall-4                    2000000              3743 ns/op             816 B/op          5 allocs/op
BenchmarkJsonParserDelSmall-4                    3000000              2936 ns/op               0 B/op          0 allocs/op
```
  